### PR TITLE
Fix millis() rollover bugs

### DIFF
--- a/src/door.cpp
+++ b/src/door.cpp
@@ -36,7 +36,7 @@ void Door::loop() {
 }
 
 void Door::updateLight(unsigned long currentMillis) {
-    if (currentMillis > previousLightUpdateMillis + config.lightUpdateInterval) {
+    if (currentMillis - previousLightUpdateMillis > config.lightUpdateInterval) {
         previousLightUpdateMillis = currentMillis;
 
         currentLight = lightMeter.readLightLevel();
@@ -90,7 +90,7 @@ void Door::executeCommand(const JsonDocument& json) {
 }
 
 void Door::publishTelemetry(unsigned long currentMillis) {
-    if (currentMillis > previousStatePublishMillis + config.statePublishingInterval) {
+    if (currentMillis - previousStatePublishMillis > config.statePublishingInterval) {
         previousStatePublishMillis = currentMillis;
 
         DynamicJsonDocument json(2048);


### PR DESCRIPTION
Since millis() returns a 32-bit long, there will be an overflow every ~50 days that was left unhandled. This way it should work.

https://www.norwegiancreations.com/2018/10/arduino-tutorial-avoiding-the-overflow-issue-when-using-millis-and-micros/