### PR TITLE
Add reset button to ignore stored configuration

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -10,7 +10,7 @@ public:
         : fileSystem(fileSystem) {
     }
 
-    void begin();
+    void begin(bool reset);
     void update(const JsonDocument& json);
     void store();
 

--- a/include/PinAllocation.h
+++ b/include/PinAllocation.h
@@ -15,6 +15,8 @@
 #define OPEN_PIN GPIO_NUM_14
 #define CLOSED_PIN GPIO_NUM_12
 
+#define  RESET_BUTTON_PIN GPIO_NUM_2
+
 #elif defined(ESP8266)
 
 #define OPEN_PIN D5
@@ -27,5 +29,7 @@
 
 #define LIGHT_SDA D7
 #define LIGHT_SCL D4
+
+#define RESET_BUTTON_PIN D8
 
 #endif

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -13,7 +13,11 @@ T getJsonValue(const JsonDocument& json, const String& key, T defaultValue) {
     }
 }
 
-void Config::begin() {
+void Config::begin(bool reset) {
+    if (reset) {
+        Serial.println("Reset during startup, not reading configuration");
+        return;
+    }
     if (fileSystem.getFS().exists(CONFIG_FILE)) {
         File configFile = fileSystem.getFS().open(CONFIG_FILE, FILE_READ);
         DynamicJsonDocument configJson(configFile.size() * 2);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ void setup() {
     Serial.begin(115200);
 
     pinMode(LED_BUILTIN, OUTPUT);
+    pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
 
     while (!Serial) {
         delay(100);
@@ -51,7 +52,8 @@ void setup() {
         return;
     }
 
-    config.begin();
+    bool reset = digitalRead(RESET_BUTTON_PIN) == LOW;
+    config.begin(reset);
 
     wifi.begin("chickens", googleIoTRootCert);
     ota.begin("chickens");


### PR DESCRIPTION
If the button is pressed during startup, the configuration stored on the file system is ignored.