### PR TITLE
Use telemetry only

### DIFF
--- a/include/MqttHandler.h
+++ b/include/MqttHandler.h
@@ -24,7 +24,7 @@ public:
         std::function<void(JsonDocument&)> onCommand);
     void loop();
 
-    void publishState(const JsonDocument& json);
+    void publishStatus(const JsonDocument& json);
     void publishTelemetry(const JsonDocument& json);
 
 private:

--- a/src/MqttHandler.cpp
+++ b/src/MqttHandler.cpp
@@ -87,7 +87,7 @@ void MqttHandler::loop() {
     }
 }
 
-void MqttHandler::publishState(const JsonDocument& json) {
+void MqttHandler::publishStatus(const JsonDocument& json) {
     String payload;
     serializeJson(json, payload);
     mqtt->publishTelemetry("/status", payload);

--- a/src/MqttHandler.cpp
+++ b/src/MqttHandler.cpp
@@ -90,9 +90,9 @@ void MqttHandler::loop() {
 void MqttHandler::publishState(const JsonDocument& json) {
     String payload;
     serializeJson(json, payload);
-    mqtt->publishState(payload);
+    mqtt->publishTelemetry("/status", payload);
 #ifdef DUMP_MQTT
-    Serial.print("Published state: ");
+    Serial.print("Published status: ");
     serializeJsonPretty(json, Serial);
     Serial.println();
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ void setup() {
         populateEvent(event);
         JsonObject telemetry = root.createNestedObject("telemetry");
         telemetryProvider.populateTelemetry(telemetry);
-        mqtt.publishState(doc);
+        mqtt.publishStatus(doc);
     });
     light.setOnUpdate([](float light) {
         door.lightChanged(light);


### PR DESCRIPTION
Fixes #69

Instead of using the device state topic that is throttled to 1/sec, publish device status as a sub-telemetry instead. This way we'll get all the events from the device, even when they arrive in quick succession.