### PR TITLE
Enable manual override

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.json]
+indent_size = 2

--- a/google-iot/state-publish/src/js/index.js
+++ b/google-iot/state-publish/src/js/index.js
@@ -36,14 +36,14 @@ function describeEvent(event) {
 
 function describeState(state) {
     switch (state) {
-        case 0:
+        case 2:
             return "open";
         case 1:
-            return "closed";
-        case 2:
             return "opening";
-        case 3:
+        case -1:
             return "closing";
+        case -2:
+            return "closed";
         default:
             return `unknown (${state})`;
     }

--- a/google-iot/state-publish/src/js/index.js
+++ b/google-iot/state-publish/src/js/index.js
@@ -23,12 +23,14 @@ exports.statePublish = (event, context) => {
 };
 
 function describeEvent(event) {
-    if (event.init) {
+    if (event.hasOwnProperty("init")) {
         return "Initialized";
     } else if (event.hasOwnProperty("emergencyStop")) {
         return "Emergency stop activated!";
     } else if (event.hasOwnProperty("state")) {
         return `The door is now *${describeState(event.state)}*.`;
+    } else if (event.hasOwnProperty("manualOverride")) {
+        return `Manual override is *${event.manualOverride ? "enabled" : "disabled"}*.`;
     } else {
         return `Unknown event: \`${JSON.stringify(event)}\`.`;
     }

--- a/google-iot/state-publish/src/js/package.json
+++ b/google-iot/state-publish/src/js/package.json
@@ -4,5 +4,8 @@
     "dependencies": {
         "@google-cloud/pubsub": "^2.10.0",
         "@slack/webhook": "^6.0.0"
+    },
+    "scripts": {
+        "start": "gcloud functions deploy statePublish --runtime nodejs14 --trigger-topic chicken-coop-door-state --set-env-vars SLACK_URL=$SLACK_URL --region europe-west1"
     }
 }

--- a/google-iot/telemetry-publish/src/js/package.json
+++ b/google-iot/telemetry-publish/src/js/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "@google-cloud/bigquery": "^5.5.0",
     "@google-cloud/pubsub": "^2.10.0"
+  },
+  "scripts": {
+    "start": "gcloud functions deploy galagonyaPublish --set-env-vars=DATASET=${DATASET},TABLE=${TABLE} --region europe-west1 --trigger-topic chicken-coop-door --runtime nodejs14 --memory 128mb"
   }
 }

--- a/include/Door.h
+++ b/include/Door.h
@@ -44,8 +44,13 @@ public:
         this->state = state;
         onEvent([state](JsonObject& json) { json["state"] = static_cast<int>(state); });
     }
+    void setManualOverride(bool manualOverride) {
+        this->manualOverride = manualOverride;
+        onEvent([manualOverride](JsonObject& json) { json["manualOverride"] = manualOverride; });
+    }
     void lightChanged(float light);
     void populateTelemetry(JsonObject& json) override {
+        json["manualOverride"] = manualOverride;
         json["emergencyStop"] = emergencyStop;
         json["gate"] = static_cast<int>(state);
         json["motorPosition"] = motor.currentPosition();
@@ -62,6 +67,11 @@ private:
      * The state of the gate.
      */
     GateState state;
+
+    /**
+     * Ignore light levels, and keep open or closed until further notice.
+     */
+    bool manualOverride = false;
 
     /**
      * Is the door disabled because its movement timed out?

--- a/include/Door.h
+++ b/include/Door.h
@@ -13,10 +13,10 @@
 #include "Telemetry.h"
 
 enum class GateState {
-    OPEN,
-    CLOSED,
-    OPENING,
-    CLOSING
+    CLOSED  = -2,
+    CLOSING = -1,
+    OPENING = 1,
+    OPEN = 2
 };
 
 class Door

--- a/src/Door.cpp
+++ b/src/Door.cpp
@@ -31,6 +31,10 @@ void Door::begin(std::function<void(std::function<void(JsonObject&)>)> onEvent) 
 }
 
 void Door::lightChanged(float light) {
+    // Ignore light changes when in manual override mode
+    if (manualOverride) {
+        return;
+    }
     if (light < config.closeLightLimit && state != GateState::CLOSED && state != GateState::CLOSING) {
         Serial.println("Closing...");
         startMoving(GateState::CLOSING);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,10 +84,11 @@ void setup() {
                 Serial.println("Moving door to " + String(targetPosition));
                 door.moveTo(targetPosition);
             }
-            if (json.containsKey("setState")) {
-                int targetStateValue = json["setState"];
+            if (json.containsKey("state")) {
+                int targetStateValue = json["state"];
                 GateState targetState = static_cast<GateState>(targetStateValue);
                 Serial.println("Setting door state to " + String(targetStateValue));
+                door.setManualOverride(true);
                 door.setState(targetState);
             }
             if (json.containsKey("update")) {


### PR DESCRIPTION
When state is set via a command, it now enters manual override. The override can only be cleared currently by restarting the system.

Values for the gate state enum have been reworked, too.

Fixes #72.