### PR TITLE
Manual override to reset movement timeout

### DIFF
--- a/include/Door.h
+++ b/include/Door.h
@@ -40,13 +40,10 @@ public:
     void moveTo(long position) {
         motor.moveTo(position);
     }
-    void setState(GateState state) {
-        this->state = state;
-        onEvent([state](JsonObject& json) { json["state"] = static_cast<int>(state); });
-    }
-    void setManualOverride(bool manualOverride) {
-        this->manualOverride = manualOverride;
-        onEvent([manualOverride](JsonObject& json) { json["manualOverride"] = manualOverride; });
+    void override(GateState state) {
+        this->manualOverride = true;
+        onEvent([](JsonObject& json) { json["manualOverride"] = true; });
+        startMoving(state);
     }
     void lightChanged(float light);
     void populateTelemetry(JsonObject& json) override {
@@ -77,6 +74,11 @@ private:
      * Is the door disabled because its movement timed out?
      */
     bool emergencyStop = false;
+
+    void setState(GateState state) {
+        this->state = state;
+        onEvent([state](JsonObject& json) { json["state"] = static_cast<int>(state); });
+    }
 
     /**
      * Starts to move the motor towards opening or closing.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,12 +84,11 @@ void setup() {
                 Serial.println("Moving door to " + String(targetPosition));
                 door.moveTo(targetPosition);
             }
-            if (json.containsKey("state")) {
-                int targetStateValue = json["state"];
+            if (json.containsKey("override")) {
+                int targetStateValue = json["override"];
                 GateState targetState = static_cast<GateState>(targetStateValue);
                 Serial.println("Setting door state to " + String(targetStateValue));
-                door.setManualOverride(true);
-                door.setState(targetState);
+                door.override(targetState);
             }
             if (json.containsKey("update")) {
                 String url = json["update"];


### PR DESCRIPTION
Previously manual override did not reset the movement timeout, and could result in a timeout when the state was overridden right after the door opened or closed.