### PR TITLE
Add resume command

### DIFF
--- a/include/Door.h
+++ b/include/Door.h
@@ -46,6 +46,10 @@ public:
         onEvent([](JsonObject& json) { json["manualOverride"] = true; });
         startMoving(state);
     }
+    void resume() {
+        this->manualOverride = false;
+        onEvent([](JsonObject& json) { json["manualOverride"] = false; });
+    }
     void lightChanged(float light);
     void populateTelemetry(JsonObject& json) override {
         json["manualOverride"] = manualOverride;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,10 @@ void setup() {
                 Serial.println("Setting door state to " + String(targetStateValue));
                 door.override(targetState);
             }
+            if (json.containsKey("resume")) {
+                Serial.println("Resuminmg normal operation");
+                door.resume();
+            }
             if (json.containsKey("update")) {
                 String url = json["update"];
                 httpUpdateHandler.update(url, VERSION);


### PR DESCRIPTION
Now after an `{ override: x }` the operation can be resumed via `{ resume: true }`. Previously resuming required restarting the whole device.

Fixes #96.