### PR TITLE
Disable SIM on LilyGo board

### DIFF
--- a/include/pins_arduino_ttgo_call.h
+++ b/include/pins_arduino_ttgo_call.h
@@ -12,14 +12,24 @@
 #define digitalPinHasPWM(p)         (p < 34)
 
 // Sim800
+#if defined(SIM800C)
+#define SIM800_TX 27
+#define SIM800_RX 26
+#define PWKEY 4
+#define SIM800_RST -1
+#define SIM800_POWER 25
+
+static const uint8_t LED_BUILTIN = 12;
+#elif defined(SIM800L)
 #define SIM800_TX 26
 #define SIM800_RX 27
 #define PWKEY 4
 #define SIM800_RST 5
 #define SIM800_POWER 23
 
-
 static const uint8_t LED_BUILTIN = 13;
+#endif
+
 #define BUILTIN_LED  LED_BUILTIN // backward compatibility
 
 static const uint8_t TX = 1;

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,3 +46,4 @@ monitor_filters = esp32_exception_decoder
 build_flags =
 ;     -DUSE_GOOGLE_LTS_DOMAIN
     -DDUMP_MQTT
+    -DSIM800C

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,12 @@ void setup() {
     pinMode(LED_BUILTIN, OUTPUT);
     pinMode(RESET_BUTTON_PIN, INPUT_PULLUP);
 
+#if defined(SIM800_POWER)
+    // Disable SIM800 module on LilyGo board
+    pinMode(SIM800_POWER, OUTPUT);
+    digitalWrite(SIM800_POWER, LOW);
+#endif
+
     while (!Serial) {
         delay(100);
     }


### PR DESCRIPTION
It is possible that it draws current at some points in time, causing the system to malfunction.