### PR TITLE
Use interrupts to detect door state changes

### DIFF
--- a/include/AbstractDoor.h
+++ b/include/AbstractDoor.h
@@ -22,10 +22,10 @@ class AbstractDoor
       protected ConfigAware,
       protected Loopable<bool> {
 public:
-    AbstractDoor(const Config& config, SwitchHandler& openSwitch, SwitchHandler& closedSwitch)
+    AbstractDoor(const Config& config, SwitchHandler& openSwitch, SwitchHandler& closeSwitch)
         : ConfigAware(config)
         , openSwitch(openSwitch)
-        , closedSwitch(closedSwitch) {
+        , closeSwitch(closeSwitch) {
     }
 
     void begin(std::function<bool(std::function<void(JsonObject&)>)> onEvent);
@@ -59,7 +59,7 @@ protected:
     virtual void disableMotor() = 0;
 
     SwitchHandler& openSwitch;
-    SwitchHandler& closedSwitch;
+    SwitchHandler& closeSwitch;
 
     std::function<bool(std::function<void(JsonObject&)>)> onEvent;
 

--- a/include/AbstractDoor.h
+++ b/include/AbstractDoor.h
@@ -12,6 +12,7 @@
 enum class GateState {
     CLOSED = -2,
     CLOSING = -1,
+    UNKNOWN = 0,
     OPENING = 1,
     OPEN = 2
 };
@@ -27,7 +28,7 @@ public:
         , closedSwitch(closedSwitch) {
     }
 
-    void begin(std::function<void(std::function<void(JsonObject&)>)> onEvent);
+    void begin(std::function<bool(std::function<void(JsonObject&)>)> onEvent);
 
     /**
      * Loops the door, and returns whether the door is currently moving.
@@ -60,12 +61,17 @@ protected:
     SwitchHandler& openSwitch;
     SwitchHandler& closedSwitch;
 
-    std::function<void(std::function<void(JsonObject&)>)> onEvent;
+    std::function<bool(std::function<void(JsonObject&)>)> onEvent;
 
     /**
      * The state of the gate.
      */
-    GateState state;
+    GateState state = GateState::UNKNOWN;
+
+    /**
+     * The state we last reported.
+     */
+    GateState reportedState = GateState::UNKNOWN;
 
     /**
      * Ignore light levels, and keep open or closed until further notice.
@@ -79,7 +85,6 @@ protected:
 
     void setState(GateState state) {
         this->state = state;
-        onEvent([state](JsonObject& json) { json["state"] = static_cast<int>(state); });
     }
 
     /**

--- a/include/MqttHandler.h
+++ b/include/MqttHandler.h
@@ -27,8 +27,8 @@ public:
         std::function<void(JsonDocument&)> onCommand);
     void loop() override;
 
-    void publishStatus(const JsonDocument& json);
-    void publishTelemetry(const JsonDocument& json);
+    bool publishStatus(const JsonDocument& json);
+    bool publishTelemetry(const JsonDocument& json);
 
 private:
     String getJwt();

--- a/include/SimpleDoor.h
+++ b/include/SimpleDoor.h
@@ -13,8 +13,8 @@ class SimpleDoor
     : public AbstractDoor {
 
 public:
-    SimpleDoor(const Config& config, SwitchHandler& openSwitch, SwitchHandler& closedSwitch)
-        : AbstractDoor(config, openSwitch, closedSwitch)
+    SimpleDoor(const Config& config, SwitchHandler& openSwitch, SwitchHandler& closeSwitch)
+        : AbstractDoor(config, openSwitch, closeSwitch)
         , motor(AccelStepper::FULL4WIRE, MOTOR_PIN1, MOTOR_PIN3, MOTOR_PIN2, MOTOR_PIN4) {
     }
 

--- a/src/AbstractDoor.cpp
+++ b/src/AbstractDoor.cpp
@@ -9,13 +9,13 @@ void AbstractDoor::begin(std::function<bool(std::function<void(JsonObject&)>)> o
     // Set initial state
     String message;
     if (openSwitch.isEngaged()) {
-        if (closedSwitch.isEngaged()) {
+        if (closeSwitch.isEngaged()) {
             halt("Both open and close switches are engaged");
             return;
         }
         message = "Door initialized in open state";
         state = GateState::OPEN;
-    } else if (closedSwitch.isEngaged()) {
+    } else if (closeSwitch.isEngaged()) {
         message = "Door initialized in closed state";
         state = GateState::CLOSED;
     } else {
@@ -62,7 +62,7 @@ bool AbstractDoor::loop() {
     }
 
     if (state == GateState::CLOSING) {
-        if (closedSwitch.isEngaged()) {
+        if (closeSwitch.isEngaged()) {
             Serial.println("Closed");
             stopMoving(GateState::CLOSED);
         } else {

--- a/src/AbstractDoor.cpp
+++ b/src/AbstractDoor.cpp
@@ -1,6 +1,6 @@
 #include "Door.h"
 
-void AbstractDoor::begin(std::function<void(std::function<void(JsonObject&)>)> onEvent) {
+void AbstractDoor::begin(std::function<bool(std::function<void(JsonObject&)>)> onEvent) {
     this->onEvent = onEvent;
 
     initializeMotor();
@@ -46,6 +46,12 @@ void AbstractDoor::lightChanged(float light) {
 }
 
 bool AbstractDoor::loop() {
+    if (state != reportedState) {
+        if (onEvent([this](JsonObject& json) { json["state"] = static_cast<int>(state); })) {
+            reportedState = state;
+        }
+    }
+
     bool movementExpected = !emergencyStop
         && config.motorEnabled
         && isMoving();

--- a/src/MqttHandler.cpp
+++ b/src/MqttHandler.cpp
@@ -90,30 +90,32 @@ void MqttHandler::loop() {
     mqtt->loop();
 }
 
-void MqttHandler::publishStatus(const JsonDocument& json) {
+bool MqttHandler::publishStatus(const JsonDocument& json) {
     if (mqttClient == nullptr || !mqttClient->connected()) {
-        return;
+        return false;
     }
     String payload;
     serializeJson(json, payload);
-    mqtt->publishTelemetry("/status", payload);
+    bool success = mqtt->publishTelemetry("/status", payload);
 #ifdef DUMP_MQTT
     Serial.print("Published status: ");
     serializeJsonPretty(json, Serial);
     Serial.println();
 #endif
+    return success;
 }
 
-void MqttHandler::publishTelemetry(const JsonDocument& json) {
+bool MqttHandler::publishTelemetry(const JsonDocument& json) {
     if (mqttClient == nullptr || !mqttClient->connected()) {
-        return;
+        return false;
     }
     String payload;
     serializeJson(json, payload);
-    mqtt->publishTelemetry(payload);
+    bool success = mqtt->publishTelemetry(payload);
 #ifdef DUMP_MQTT
     Serial.print("Published telemetry: ");
     serializeJsonPretty(json, Serial);
     Serial.println();
 #endif
+    return success;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,13 +24,13 @@ WiFiHandler wifi(config, "chickens");
 
 LightHandler light(config);
 SwitchHandler openSwitch("openSwitch", OPEN_PIN, []() { return config.invertOpenSwitch; });
-SwitchHandler closedSwitch("closedSwitch", CLOSED_PIN, []() { return config.invertCloseSwitch; });
-Door door(config, openSwitch, closedSwitch);
+SwitchHandler closeSwitch("closedSwitch", CLOSED_PIN, []() { return config.invertCloseSwitch; });
+Door door(config, openSwitch, closeSwitch);
 
 NtpHandler ntp(wifi);
 MqttHandler mqtt(wifi, ntp);
 HttpUpdateHandler httpUpdateHandler(wifi);
-CompositeTelemetryProvider telemetryProvider({ &light, &openSwitch, &closedSwitch, &door });
+CompositeTelemetryProvider telemetryProvider({ &light, &openSwitch, &closeSwitch, &door });
 TelemetryPublisher telemetryPublisher(config, mqtt, telemetryProvider);
 
 void fatalError(String message) {
@@ -108,7 +108,7 @@ void setup() {
 
     light.begin(LIGHT_SDA, LIGHT_SCL);
     openSwitch.begin();
-    closedSwitch.begin();
+    closeSwitch.begin();
     door.begin([](std::function<void(JsonObject&)> populateEvent) {
         DynamicJsonDocument doc(2048);
         JsonObject root = doc.to<JsonObject>();
@@ -129,7 +129,7 @@ void loop() {
     ota.loop();
     light.loop();
     openSwitch.loop();
-    closedSwitch.loop();
+    closeSwitch.loop();
     bool moving = door.loop();
     if (wifi.loop()) {
         telemetryPublisher.loop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,8 +128,6 @@ void setup() {
 void loop() {
     ota.loop();
     light.loop();
-    openSwitch.loop();
-    closeSwitch.loop();
     bool moving = door.loop();
     if (wifi.loop()) {
         telemetryPublisher.loop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ void setup() {
         populateEvent(event);
         JsonObject telemetry = root.createNestedObject("telemetry");
         telemetryProvider.populateTelemetry(telemetry);
-        mqtt.publishStatus(doc);
+        return mqtt.publishStatus(doc);
     });
     light.setOnUpdate([](float light) {
         door.lightChanged(light);


### PR DESCRIPTION
Instead of querying the door state periodically, use interrupts on the switches to track the changes.

Another change introduced in this PR is to keep resending status change events until they actually get published.