### PR TITLE
Follow HTTP redirects when updating firmware

### DIFF
--- a/include/HttpUpdateHandler.h
+++ b/include/HttpUpdateHandler.h
@@ -13,6 +13,7 @@ class HttpUpdateHandler {
 public:
     HttpUpdateHandler(WiFiHandler& wifi)
         : wifi(wifi) {
+        httpUpdate.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
     }
 
     void update(const String& url, const String& version) {


### PR DESCRIPTION
This is required to update via a GitHub release URL for example.